### PR TITLE
Catch PHP exception thrown during callback execution

### DIFF
--- a/tests/017.phpt
+++ b/tests/017.phpt
@@ -1,0 +1,43 @@
+--TEST--
+Catch Exception from PHP callback 
+--SKIPIF--
+<?php if (!extension_loaded("lua")) print "skip"; ?>
+--FILE--
+<?php 
+
+function throw_me() {
+	throw new \Exception('It happened');
+}
+
+function call_me() {
+	return "called after exception";
+}
+
+$l = new lua();
+$l->registerCallback('throw_me', 'throw_me');
+$l->registerCallback('call_me', 'call_me');
+
+$l->eval(<<<'CODE'
+local t, err = pcall(throw_me)
+
+print("Exception caught in Lua: " .. tostring(t) .. ", message: " .. tostring(err) .. "\n")
+
+local called = call_me()
+print(called .. "\n")
+CODE
+);
+
+try {
+	$l->eval(<<<'CODE'
+	local value = throw_me()
+CODE
+);
+} catch (\Throwable $e) {
+	print "Caught in PHP: {$e->getMessage()}\n";
+}
+
+?>
+--EXPECTF--
+Exception caught in Lua: false, message: It happened
+called after exception
+Caught in PHP: It happened


### PR DESCRIPTION
Apart from a result, PHP callback can throw an excetion. Thrown exception
is stored it global variable "exception" until it's caught. Once this variable
is set, PHP internal methods stop working considering they are in an
stack-unwinding process. As soon as lua extension doesn't cleanup this state,
all following callbacks return nil until the exceptoin is caught and the
state is cleaned up.

However, the exception is caught only when lua code is done and execution flow is
returned to PHP again.